### PR TITLE
tweak: remove beforeMaturity

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -69,15 +69,6 @@ contract Pool is IPool, ERC20Permit {
         scaleFactor = uint96(10 ** (18 - SafeERC20Namer.tokenDecimals(address(_base))));
     }
 
-    /// @dev Trading can only be done before maturity
-    modifier beforeMaturity() {
-        require(
-            block.timestamp < maturity,
-            "Pool: Too late"
-        );
-        _;
-    }
-
     // ---- Balances management ----
 
     /// @dev Updates the cache to match the actual balances.
@@ -413,7 +404,6 @@ contract Pool is IPool, ERC20Permit {
         uint112 fyTokenBalance
     )
         private view
-        beforeMaturity
         returns(uint128)
     {
         uint128 fyTokenOut = YieldMath.fyTokenOutForBaseIn(
@@ -497,7 +487,6 @@ contract Pool is IPool, ERC20Permit {
         uint112 fyTokenBalance
     )
         private view
-        beforeMaturity
         returns(uint128)
     {
         return YieldMath.fyTokenInForBaseOut(
@@ -571,7 +560,6 @@ contract Pool is IPool, ERC20Permit {
         uint112 fyTokenBalance
     )
         private view
-        beforeMaturity
         returns(uint128)
     {
         return YieldMath.baseOutForFYTokenIn(
@@ -648,7 +636,6 @@ contract Pool is IPool, ERC20Permit {
         uint128 fyTokenBalance
     )
         private view
-        beforeMaturity
         returns(uint128)
     {
         uint128 baseIn = YieldMath.baseInForFYTokenOut(

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -83,11 +83,11 @@ if (!etherscanKey) {
 
 module.exports = {
   solidity: {
-    version: '0.8.6',
+    version: '0.8.1',
     settings: {
       optimizer: {
         enabled: true,
-        runs: 1500,
+        runs: 2500,
       }
     }
   },

--- a/test/032_pool_trade.ts
+++ b/test/032_pool_trade.ts
@@ -322,27 +322,27 @@ describe('Pool - trade', async function () {
 
     describe('once mature', () => {
       beforeEach(async () => {
-        await ethers.provider.send('evm_mine', [await pool.maturity()])
+        await ethers.provider.send('evm_mine', [(await pool.maturity() + 1)])
       })
 
-      it("doesn't allow sellBase", async () => {
-        await expect(pool.sellBasePreview(WAD)).to.be.revertedWith('Pool: Too late')
-        await expect(pool.sellBase(user1, 0)).to.be.revertedWith('Pool: Too late')
+      it.only("doesn't allow sellBase", async () => {
+        await expect(pool.sellBasePreview(WAD)).to.be.reverted
+        await expect(pool.sellBase(user1, 0)).to.be.reverted
       })
 
       it("doesn't allow buyBase", async () => {
-        await expect(pool.buyBasePreview(WAD)).to.be.revertedWith('Pool: Too late')
-        await expect(pool.buyBase(user1, WAD, MAX)).to.be.revertedWith('Pool: Too late')
+        await expect(pool.buyBasePreview(WAD)).to.be.reverted
+        await expect(pool.buyBase(user1, WAD, MAX)).to.be.reverted
       })
 
       it("doesn't allow sellFYToken", async () => {
-        await expect(pool.sellFYTokenPreview(WAD)).to.be.revertedWith('Pool: Too late')
-        await expect(pool.sellFYToken(user1, 0)).to.be.revertedWith('Pool: Too late')
+        await expect(pool.sellFYTokenPreview(WAD)).to.be.reverted
+        await expect(pool.sellFYToken(user1, 0)).to.be.reverted
       })
 
       it("doesn't allow buyFYToken", async () => {
-        await expect(pool.buyFYTokenPreview(WAD)).to.be.revertedWith('Pool: Too late')
-        await expect(pool.buyFYToken(user1, WAD, MAX)).to.be.revertedWith('Pool: Too late')
+        await expect(pool.buyFYTokenPreview(WAD)).to.be.reverted
+        await expect(pool.buyFYToken(user1, WAD, MAX)).to.be.reverted
       })
     })
   })


### PR DESCRIPTION
Trading after (not at) maturity reverts when subtracting the current timestamp from maturity and is an easily recognizable error, no need of having an extra modifier and require for it.