### PR TITLE
fix: check sandwiching from cached values. Burn from cached values.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/yieldspace-v2",
-  "version": "0.11.0-rc7",
+  "version": "0.11.0-rc8",
   "description": "YieldSpace v2 contracts",
   "author": "Yield Inc.",
   "files": [

--- a/test/031_pool_mint.ts
+++ b/test/031_pool_mint.ts
@@ -141,7 +141,7 @@ describe('Pool - mint', async function () {
       await pool.sync()
     })
 
-    it('mints liquidity tokens, leaving base surplus', async () => {
+    it('mints liquidity tokens, returning base surplus', async () => {
       const fyTokenIn = WAD
 
       const [expectedMinted, expectedBaseIn] = await poolEstimator.mint(fyTokenIn)
@@ -204,6 +204,7 @@ describe('Pool - mint', async function () {
       await base.mint(pool.address, WAD)
       const minRatio = WAD.mul(await base.balanceOf(pool.address)).div(await fyToken.balanceOf(pool.address))
       await fyToken.mint(pool.address, WAD)
+      await pool.sync()
       await expect(pool.mintWithBase(user2, user2, fyTokenToBuy, minRatio, MAX, OVERRIDES)).to.be.revertedWith(
         'Pool: Reserves ratio changed'
       )
@@ -214,6 +215,7 @@ describe('Pool - mint', async function () {
       await base.mint(pool.address, WAD)
       const maxRatio = WAD.mul(await base.balanceOf(pool.address)).div(await fyToken.balanceOf(pool.address))
       await base.mint(pool.address, WAD)
+      await pool.sync()
       await expect(pool.mintWithBase(user2, user2, fyTokenToBuy, 0, maxRatio, OVERRIDES)).to.be.revertedWith(
         'Pool: Reserves ratio changed'
       )
@@ -282,6 +284,7 @@ describe('Pool - mint', async function () {
       await pool.transfer(pool.address, lpTokensIn)
       const minRatio = WAD.mul(await base.balanceOf(pool.address)).div(await fyToken.balanceOf(pool.address))
       await fyToken.mint(pool.address, WAD)
+      await pool.sync()
       await expect(pool.burnForBase(user2, minRatio, MAX, OVERRIDES)).to.be.revertedWith('Pool: Reserves ratio changed')
     })
 
@@ -290,6 +293,7 @@ describe('Pool - mint', async function () {
       await pool.transfer(pool.address, lpTokensIn)
       const maxRatio = WAD.mul(await base.balanceOf(pool.address)).div(await fyToken.balanceOf(pool.address))
       await base.mint(pool.address, WAD)
+      await pool.sync()
       await expect(pool.burnForBase(user2, 0, maxRatio, OVERRIDES)).to.be.revertedWith('Pool: Reserves ratio changed')
     })
   })


### PR DESCRIPTION
Two fixes:
 - The slippage checks (actually sandwiching checks) use the cached reserves, so that the assets sent to the pool for the mint don't affect the ratio check. Same done in burn for symmetry
 - Found that the mint is done on cached reserves, but burn was done on actual reserves. Now it is cached reserves on both.