### PR TITLE
draft: permissioned init

### DIFF
--- a/contracts/mocks/WETH9Mock.sol
+++ b/contracts/mocks/WETH9Mock.sol
@@ -29,4 +29,9 @@ contract WETH9Mock is ERC20 {
     function totalSupply() public view override returns (uint) {
         return address(this).balance;
     }
+
+    /// @dev Give tokens to whoever asks for them.
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, amount);
+    }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
-    "@yield-protocol/utils-v2": "^2.4.1",
+    "@yield-protocol/utils-v2": "^2.5.1",
     "@yield-protocol/vault-interfaces": "^2.0.41",
     "@yield-protocol/yieldspace-interfaces": "^2.3.0-rc7",
     "chai": "4.2.0",

--- a/test/033_pool_usdc.ts
+++ b/test/033_pool_usdc.ts
@@ -54,7 +54,7 @@ describe('Pool - usdc', async function () {
   const fyTokenId = baseId + '-' + maturityId
 
   async function fixture() {
-    return await YieldSpaceEnvironment.setup(ownerAcc, [], [maturityId], BigNumber.from('0'))
+    return await YieldSpaceEnvironment.setup(ownerAcc, [], [maturityId])
   }
 
   before(async () => {
@@ -76,7 +76,7 @@ describe('Pool - usdc', async function () {
     maturity = BigNumber.from(await fyToken.maturity())
 
     await base.mint(pool.address, initialBase)
-    await pool.connect(user1Acc).mint(user1, user1, 0, MAX)
+    await pool.connect(ownerAcc).init(user1)
   })
 
   it('sells fyToken', async () => {

--- a/test/034_pool_mintWithBase.ts
+++ b/test/034_pool_mintWithBase.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { constants } from '@yield-protocol/utils-v2'
+import { constants, id } from '@yield-protocol/utils-v2'
 const { WAD, MAX128 } = constants
 const MAX = MAX128
 
@@ -78,7 +78,7 @@ describe('Pool - mintWithBase', async function () {
   const scaleFactor = BigNumber.from('1')
 
   async function fixture() {
-    return await YieldSpaceEnvironment.setup(ownerAcc, [baseId], [maturityId], initialBase)
+    return await YieldSpaceEnvironment.setup(ownerAcc, [baseId], [maturityId])
   }
 
   before(async () => {
@@ -117,7 +117,7 @@ describe('Pool - mintWithBase', async function () {
 
               // Initialize to supply
               await base.mint(pool.address, poolSupply)
-              await pool.mint(owner, owner, 0, MAX)
+              await pool.connect(ownerAcc).init(owner)
 
               // Donate to reserves
               const baseDonation = baseReserve.sub(poolSupply)

--- a/test/035_pool_twar.ts
+++ b/test/035_pool_twar.ts
@@ -49,7 +49,7 @@ describe('Pool - TWAR', async function () {
   const fyTokenId = baseId + '-' + maturityId
 
   async function fixture() {
-    return await YieldSpaceEnvironment.setup(ownerAcc, [baseId], [maturityId], BigNumber.from('0'))
+    return await YieldSpaceEnvironment.setup(ownerAcc, [baseId], [maturityId])
   }
 
   before(async () => {
@@ -70,7 +70,7 @@ describe('Pool - TWAR', async function () {
     poolFromUser1 = pool.connect(user1Acc)
 
     await base.mint(pool.address, initialBase)
-    await poolFromUser1.mint(user1, user1, 0, MAX)
+    await pool.init(user1)
   })
 
   it('calculates the TWAR price', async () => {

--- a/test/036_pool_extensions.ts
+++ b/test/036_pool_extensions.ts
@@ -50,7 +50,7 @@ describe('YieldMathExtensions - allowances', async function () {
   const fyTokenId = baseId + '-' + maturityId
 
   async function fixture() {
-    return await YieldSpaceEnvironment.setup(ownerAcc, [], [maturityId], BigNumber.from('0'))
+    return await YieldSpaceEnvironment.setup(ownerAcc, [], [maturityId])
   }
 
   before(async () => {
@@ -72,7 +72,7 @@ describe('YieldMathExtensions - allowances', async function () {
     maturity = BigNumber.from(await fyToken.maturity())
 
     await base.mint(pool.address, bases)
-    await pool.connect(user1Acc).mint(user1, user1, 0, MAX)
+    await pool.init(user1)
 
     const yieldMathLibrary = await ((await ethers.getContractFactory('YieldMath')) as YieldMath__factory).deploy()
     await yieldMathLibrary.deployed()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,10 +2291,10 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@yield-protocol/utils-v2@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/utils-v2/-/utils-v2-2.4.1.tgz#063fbd0c12cff15c70215a202b28fb1459b5ed51"
-  integrity sha512-PyLNLNjZfwbLD3CvDngnebUpRJtb+aWUdIKVgzxRGrYxahahhJfRQQL+dzIUyQ0pGu56CgvL/A5PFQ3VH52bpw==
+"@yield-protocol/utils-v2@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/utils-v2/-/utils-v2-2.5.1.tgz#e720c31df004d6f5252e829de15badf9fa2f21b9"
+  integrity sha512-gudSzZYLM65L00S59oiG8qRzRbmjfMFKC2LUhsivVQQTuTKI1RroWXNYkT4FX6HyVt5Op1lXqv3C8/G29IugqQ==
   dependencies:
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"


### PR DESCRIPTION
`pool.init` is being made a permissioned function to avoid sandwiching attacks on creation. Using AccessControl will allow also adding a function to modify g1 and g2 on live pools.